### PR TITLE
Fix cheat code events bubbling up to the browser

### DIFF
--- a/cheet.js
+++ b/cheet.js
@@ -152,7 +152,7 @@ THE SOFTWARE.
     this.idx = 0;
   };
 
-  Sequence.prototype.keydown = function keydown (keyCode) {
+  Sequence.prototype.keydown = function keydown (keyCode, eventObj) {
     var i = this.idx;
     if (keyCode !== this.keys[i]) {
       if (i > 0) {
@@ -171,6 +171,9 @@ THE SOFTWARE.
       cheet.__done(this.str);
       this.idx = 0;
     }
+
+    eventObj.stopPropagation();
+    eventObj.preventDefault();
   };
 
   cheet = function cheet (str, handlers) {
@@ -193,13 +196,14 @@ THE SOFTWARE.
 
   function keydown (e) {
     var id,
-        k = e ? e.keyCode : event.keyCode;
+        eventObj = e || window.event,
+        k = eventObj.keyCode;
 
     if (held[k]) return;
     held[k] = true;
 
     for (id in sequences) {
-      sequences[id].keydown(k);
+      sequences[id].keydown(k, eventObj);
     }
   }
 


### PR DESCRIPTION
Some keys are used as browser shortcut keys. If these are part of a
sequence, the browser may intercept the key events and take focus away
from the page.

For example, the Firefox `accessibility.typeaheadfind` feature pops the
search box open when any letter/number key is pressed. This makes
entering a cheat code impossible, since every keypress after the first
goes to the search box.

The solution is to call the `.stopPropagation()` and
`.preventDefault()` methods on the key event object for keys you care
about receiving so those events don't bubble up to the browser. This
commit prevents events from propagating if they contribute to an active
sequence. It might make sense to trap any keys that are part of any
sequence, regardless of whether they're the "next" key in any sequence.
